### PR TITLE
move organizers section back to the 2019 page!

### DIFF
--- a/2019/index.md
+++ b/2019/index.md
@@ -34,9 +34,10 @@ infrastructure.
 
 ## Organizers
 
-Uma Srinivasan (Twitter),
-Chris Thalinger (Twitter),
-Flavio Brasil (Twitter)
+[Uma Srinivasan](https://twitter.com/umatweep) (Twitter),
+[Chris Thalinger](https://twitter.com/christhalinger) (Twitter),
+[Flavio Brasil](https://twitter.com/flaviowbrasil) (Twitter),
+[Danny McClanahan](https://twitter.com/hipsterelectron) (Twitter)
 
 ## Program Committee
 
@@ -49,4 +50,4 @@ Flavio Brasil (Twitter)
 
 ## Other years
 
-* 2020, San Diego (upcoming)
+* 2020 *(planned)*

--- a/2019/index.md
+++ b/2019/index.md
@@ -12,6 +12,8 @@ opportunities with Graal on benchmarks and applications, developing new
 features and optimizations in Graal, creative and novel uses of the Graal
 infrastructure.
 
+Check out and join the discussion on Twitter in [`#graalcgo2019`](https://twitter.com/search?q=%23graalcgo2019&src=typd)!
+
 <img src="group.jpeg" class="rounded img-fluid">
 
 ## Presentations

--- a/index.md
+++ b/index.md
@@ -12,4 +12,4 @@ infrastructure.
 # Editions
 
 * [2019, Washington DC](2019/)
-* 2020, San Diego (upcoming)
+* 2020 *(planned)*

--- a/index.md
+++ b/index.md
@@ -9,16 +9,7 @@ opportunities with Graal on benchmarks and applications, developing new
 features and optimizations in Graal, creative and novel uses of the Graal
 infrastructure.
 
-Check out and join the discussion on Twitter in [`#graalcgo2019`](https://twitter.com/search?q=%23graalcgo2019&src=typd)!
-
-# Organizers
-
-- [Uma Srinivasan](https://twitter.com/umatweep)
-- [Chris Thalinger](https://twitter.com/christhalinger)
-- [Flavio Brasil](https://twitter.com/flaviowbrasil)
-- [Danny McClanahan](https://twitter.com/hipsterelectron)
-
 # Editions
 
 * [2019, Washington DC](2019/)
-* 2020 *(planned)*
+* 2020, San Diego (upcoming)


### PR DESCRIPTION
In #4, I mistakenly made edits to the site index -- the organizers list is only for 2019, though! This moves the hashtag and twitter handle links to the 2019 page, and notes `2020 (planned)` in both the 2019 and the index page.